### PR TITLE
fix(e2e): fix all Playwright test failures and add Docker-based runner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+linux-webui
+web/dist
+web/node_modules
+e2e/node_modules
+e2e/playwright-report
+e2e/test-results
+.git
+.claude
+*.db

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,12 +120,12 @@ jobs:
           -o linux-webui
           ./cmd/linux-webui
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-        working-directory: e2e
-
       - name: Install e2e deps
         run: npm ci
+        working-directory: e2e
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
         working-directory: e2e
 
       - name: Start server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: CI
 on:
   push:
     branches:
-      - claude/modernize-server-console-Jg45U
+      - master
+      - 'claude/**'
   pull_request:
     branches:
       - master

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,30 @@
+# Stage 1: Build frontend (Vite outputs to ../ui/dist relative to web/)
+FROM node:20-bookworm-slim AS frontend
+WORKDIR /build/web
+COPY web/package*.json ./
+RUN npm ci
+COPY web/ ./
+RUN npm run build
+# output lands at /build/ui/dist
+
+# Stage 2: Build Go binary with embedded frontend
+FROM golang:1.25-bookworm AS builder
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=frontend /build/ui/dist ./ui/dist
+RUN go build -tags production -ldflags "-X main.version=e2e" -o linux-webui ./cmd/linux-webui
+
+# Stage 3: E2E test runner (Playwright + Chromium)
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy
+WORKDIR /app
+
+COPY --from=builder /build/linux-webui ./linux-webui
+COPY e2e/ ./e2e/
+RUN cd e2e && npm ci
+
+COPY e2e/run-e2e.sh ./run-e2e.sh
+RUN chmod +x run-e2e.sh
+
+CMD ["/app/run-e2e.sh"]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ MODULE  := github.com/virajchitnis/linux-webui
 LDFLAGS := -X main.version=$(VERSION) -s -w
 GOFLAGS := -tags production
 
-.PHONY: all build dev test lint e2e clean
+.PHONY: all build dev test lint e2e e2e-docker clean
 
 all: build
 
@@ -32,6 +32,10 @@ lint:
 
 e2e:
 	cd e2e && npx playwright test
+
+e2e-docker:
+	docker build -f Dockerfile.e2e -t linux-webui-e2e .
+	docker run --rm linux-webui-e2e
 
 clean:
 	rm -f $(BINARY)

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -5,6 +5,6 @@
     "test": "playwright test"
   },
   "devDependencies": {
-    "@playwright/test": "^1.49.0"
+    "@playwright/test": "1.60.0"
   }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     baseURL: 'https://127.0.0.1:8443',
     ignoreHTTPSErrors: true,
     trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
   },
 
   projects: [

--- a/e2e/run-e2e.sh
+++ b/e2e/run-e2e.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WORKDIR=/tmp/lwui-e2e
+mkdir -p "$WORKDIR/tls"
+
+cp /app/e2e/fixtures/server.toml "$WORKDIR/config.toml"
+
+echo "Starting linux-webui server..."
+cd "$WORKDIR"
+/app/linux-webui --config "$WORKDIR/config.toml" > "$WORKDIR/server.log" 2>&1 &
+SERVER_PID=$!
+
+echo "Waiting for server to be ready..."
+for i in $(seq 1 30); do
+  if curl -sk https://127.0.0.1:8443/health > /dev/null 2>&1; then
+    echo "Server ready after ${i}s"
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "Server process died. Logs:"
+    cat "$WORKDIR/server.log"
+    exit 1
+  fi
+  sleep 1
+done
+
+if ! curl -sk https://127.0.0.1:8443/health > /dev/null 2>&1; then
+  echo "Server did not become ready in 30s. Logs:"
+  cat "$WORKDIR/server.log"
+  exit 1
+fi
+
+cd /app/e2e
+npx playwright test
+EXIT=$?
+
+echo ""
+echo "=== Server logs ==="
+cat "$WORKDIR/server.log"
+
+kill "$SERVER_PID" 2>/dev/null || true
+exit $EXIT

--- a/e2e/tests/smoke.spec.ts
+++ b/e2e/tests/smoke.spec.ts
@@ -47,7 +47,7 @@ test('login and dashboard', async ({ page }) => {
   await page.fill('input[type="password"]', ADMIN_PASS)
   await page.click('button[type="submit"]')
   await expect(page).toHaveURL(/\/dashboard/)
-  await expect(page.locator('text=Dashboard')).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()
 })
 
 test('capabilities API returns expected shape', async ({ page }) => {

--- a/internal/api/middleware/security.go
+++ b/internal/api/middleware/security.go
@@ -1,26 +1,18 @@
 package middleware
 
-import (
-	"crypto/rand"
-	"encoding/hex"
-	"net/http"
-)
+import "net/http"
 
 func SecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		nonce := csrfNonce()
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("Referrer-Policy", "strict-origin")
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		// No nonce: the embedded index.html is a static file, so we cannot inject
+		// a per-request nonce into the script tag. Use 'self' to allow same-origin
+		// scripts (the Vite bundle) and 'unsafe-inline' for Tailwind's style tags.
 		w.Header().Set("Content-Security-Policy",
-			"default-src 'self'; script-src 'self' 'nonce-"+nonce+"'; style-src 'self' 'nonce-"+nonce+"' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' wss:; frame-ancestors 'none'")
+			"default-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' wss:; frame-ancestors 'none'")
 		next.ServeHTTP(w, r)
 	})
-}
-
-func csrfNonce() string {
-	b := make([]byte, 16)
-	_, _ = rand.Read(b)
-	return hex.EncodeToString(b)
 }

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
+	"strings"
 )
 
 //go:embed all:dist
@@ -18,9 +19,14 @@ func Handler() http.Handler {
 	}
 	fileServer := http.FileServer(http.FS(sub))
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Check if file exists; if not, serve index.html for SPA routing.
-		f, err := sub.Open(r.URL.Path)
+		// fs.FS paths must not start with '/'; strip it before the existence check.
+		name := strings.TrimPrefix(r.URL.Path, "/")
+		if name == "" {
+			name = "."
+		}
+		f, err := sub.Open(name)
 		if err != nil {
+			// File not found: serve index.html for SPA client-side routing.
 			r2 := r.Clone(r.Context())
 			r2.URL.Path = "/"
 			fileServer.ServeHTTP(w, r2)


### PR DESCRIPTION
## Summary

- **Critical bug fix**: `ui/embed.go` was serving `text/html` for all asset requests (`/assets/*.js`, `/assets/*.css`) because `fs.FS.Open()` rejects paths with a leading `/`, causing the SPA fallback to trigger for every asset. React never loaded, all browser tests saw a blank white page.
- **Playwright version pin**: `^1.49.0` had drifted to `1.60.0` at install time while the Docker base image still provided Chromium for 1.49.0. Pinned to exact `1.60.0` and updated the Docker image to match.
- **CI step order fix**: `npx playwright install` was running before `npm ci`, so it installed a mismatched Playwright version. Reordered to `npm ci` → `playwright install`.
- **CSP cleanup**: The `SecurityHeaders` middleware generated a per-request nonce in `Content-Security-Policy` but never injected it into the static `index.html`. The nonce was unused dead code. Removed it; `'self'` is sufficient for the same-origin Vite bundle.
- **Locator fix**: `locator('text=Dashboard')` matched both the sidebar nav link and the page `h1`, triggering Playwright's strict-mode violation. Changed to `getByRole('heading', { name: 'Dashboard' })`.
- **Docker runner**: Added `Dockerfile.e2e`, `e2e/run-e2e.sh`, `.dockerignore`, and `make e2e-docker` so E2E tests can be run locally via Docker without installing Node, Go, or Playwright on the host.

## Test plan

- [ ] `make e2e-docker` — all 6 smoke tests pass (verified locally)
- [ ] `go test ./...` — no regressions in unit tests
- [ ] `go vet ./...` — clean
- [ ] Frontend build (`cd web && npm run build`) — clean